### PR TITLE
 Prevent download files bigger than a maxsize value

### DIFF
--- a/Products/feedfeeder/config.py
+++ b/Products/feedfeeder/config.py
@@ -16,4 +16,6 @@ UpdateAllFeeds = "feedfeeder: Update all feeds"
 DEFAULT_ADD_CONTENT_PERMISSION = AddContent
 setDefaultRoles(DEFAULT_ADD_CONTENT_PERMISSION, ('Manager', 'Owner'))
 
+maxsize = 10000 # in kb
+
 product_globals = globals()

--- a/Products/feedfeeder/content/folder.py
+++ b/Products/feedfeeder/content/folder.py
@@ -36,16 +36,6 @@ schema = Schema((
         )
     ),
     
-    IntegerField(
-         name ='maxsize',
-         widget=IntegerWidget(
-             description=_(u"Ignore files that exceed this size in kb. Leave 0 to accept all"),
-             label=_(u"maximum_size", default='Maximum file size (0 accept any size)'),
-         ),
-         default=_(u"1000"),
-         validators=('isInt'),
-     ),
-    
 ),
 )
 
@@ -98,13 +88,6 @@ class FeedfeederFolder(ATBTreeFolder):
         """
         """
         return self.feeds
-
-    security.declarePublic('getMaxsize')
-
-    def getMaxsize(self):
-        """
-        """
-        return self.maxsize
 
     security.declarePublic('replaceItem')
 


### PR DESCRIPTION
The purpose of these changes is to prevent download files bigger than a determined size. 

User selectable maxsize of files upload to a feed folder. Default is set to 1000 kb. 0 kb accepts any size.

These changes are necessary because a feed item was attempting to download a 1 GB iso image file and database errors.

Its can also prevent excessive/unwanted database growth.
