### PR TITLE
Show related items on feed items

### DIFF
--- a/Products/feedfeeder/browser/feed-item.pt
+++ b/Products/feedfeeder/browser/feed-item.pt
@@ -38,6 +38,13 @@
            tal:attributes="href context/remote_url"
            i18n:translate="source_available_here">Source available here.</a>
       </div>
+
+      <div class="related-items"
+          tal:define="field python:context.Schema()['relatedItems'];
+                      mode string:view;
+                      field_macro context/widgets/field/macros/view">
+              <metal:use_field use-macro="field_macro" />
+      </div>
     </div>
   </body>
 </html>

--- a/Products/feedfeeder/content/item.py
+++ b/Products/feedfeeder/content/item.py
@@ -82,6 +82,7 @@ schema = Schema((
 FeedFeederItem_schema = getattr(ATFolder, 'schema', Schema(())).copy() + \
     schema.copy()
 
+FeedFeederItem_schema['relatedItems'].widget.visible = {'edit': 'visible', 'view': 'visible'}
 
 class FeedFeederItem(ATFolder):
     """


### PR DESCRIPTION
Please consider this a suggestion: feed items don't act like folders, and can be usefully related to other site content, so let's display related items. 
(Context: we use [simserver](http://github.com/collective/collective.simserver.core) to generate a list of related items upon creation.)

I was a bit puzzled that feedfeeder doesn't just use normal Archetypes rendering which would include related items. 