### PR TITLE
Really call getObjectInfo when determining updated status of items

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ History of feedfeeder
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Bug fix: really call getObjectInfo() when checking if an entry was updated.
+  This avoids unnecessary updates to FeedFeederItems
+  [tiberiuichim]
 
 
 3.0.0 (2016-02-22)

--- a/Products/feedfeeder/utilities.py
+++ b/Products/feedfeeder/utilities.py
@@ -165,7 +165,7 @@ class FeedConsumer:
                 # Not new, not refreshed: let it be, laddy.  Still,
                 # the entry might have changed slightly, so we check
                 # this.
-                if prev.getObjectInfo != entry:
+                if prev.getObjectInfo() != entry:
                     # Note: no need for a reindexObject here, which
                     # would also update the modification date, which
                     # we do not want.  See


### PR DESCRIPTION
This avoids spurious growth of Data.fs on every mega update.
